### PR TITLE
Fix requirements.txt for Blackwell and overall setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,11 @@ bitsandbytes>=0.41.0
 optimum>=1.12.0
 accelerate>=0.25.0
 sageattention
-gptqmodel>=2.0.0 # Add this based on user feedback
 
-triton==3.0.0 # Higher versions seem to crash for some Windows users
+# Add this based on user feedback
+gptqmodel>=2.0.0
 
-
-    
+# 3.3.0 required for NVIDIA RTX 50xx (Blackwell)
+triton-windows==3.3.0a0.post17; sys_platform == "win32"
+# Keep Triton 3 according to earlier requirements for non-windows platforms.
+triton>=3.0.0,<3.1.0; sys_platform != "win32"


### PR DESCRIPTION
- Triton 3.3.0 is required for Blackwell architecture (RTX 50xx). Hopefully doesn't cause issues for other Windows users. Replaced triton with triton-windows for that platform.
- Triton 3.0.x kept for non-windows platforms as previous
- No single-line comments are allowed, pip currently doesn't install gptqmodel or triton on a fresh install. Comments are put on their own line.